### PR TITLE
Reset file input after handling the file (fixes #22)

### DIFF
--- a/app/views/upload_file_select.js
+++ b/app/views/upload_file_select.js
@@ -8,6 +8,7 @@ var UploadFileSelectView = Ember.TextField.extend({
     if (input.files && input.files[0]) {
       this.handleInputFile( input.files[0] );
     }
+    this.set('value', null);
   },
 
   handleInputFile: function(inputFile) {


### PR DESCRIPTION
When selecting the same file twice, the change event doesn't fire the second time. Resetting the input value makes sure, the event fires again.
