### PR TITLE
Accept all filetypes (not just images)

### DIFF
--- a/app/components/file-input.js
+++ b/app/components/file-input.js
@@ -4,9 +4,8 @@ import Component from '@ember/component';
 export default Component.extend({
 
   tagName: 'input',
-  attributeBindings: ['type', 'accept', 'multiple', 'disabled'],
+  attributeBindings: ['type', 'multiple', 'disabled'],
   type: 'file',
-  accept: 'image/*',
   multiple: false,
 
   attachment: null,


### PR DESCRIPTION
Remove the file input's `accept` attribute, so the upload file chooser doesn't hide files other than images by default.